### PR TITLE
Changes for Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,11 @@ set(LIBCANOKEY_QEMU_INCLUDEDIR ${CMAKE_INSTALL_FULL_INCLUDEDIR})
 
 file(GLOB_RECURSE SRC Src/*.c)
 
-add_library(canokey-qemu SHARED ${SRC}
+if(${APPLE})
+	add_library(canokey-qemu STATIC ${SRC}
+else()
+	add_library(canokey-qemu SHARED ${SRC}
+endif()
         canokey-core/virt-card/device-sim.c
         canokey-core/virt-card/fabrication.c
         canokey-core/littlefs/bd/lfs_filebd.c)
@@ -36,6 +40,19 @@ add_dependencies(canokey-qemu gitrev)
 install(TARGETS canokey-qemu LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-configure_file(canokey-qemu.pc.in canokey-qemu.pc @ONLY)
-install(FILES ${CMAKE_BINARY_DIR}/canokey-qemu.pc
-        DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig)
+if(${APPLE})
+	configure_file(canokey-qemu_mac.pc.in canokey-qemu.pc @ONLY)
+	install(FILES ${CMAKE_BINARY_DIR}/canokey-core/canokey-crypto/libcanokey-crypto.a
+		DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR})
+	install(FILES ${CMAKE_BINARY_DIR}/canokey-core/canokey-crypto/patched/mbedtls/library/libmbedcrypto.a
+		DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR})
+	install(FILES ${CMAKE_BINARY_DIR}/canokey-core/libcanokey-core.a 
+		DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR})
+	install(FILES ${CMAKE_BINARY_DIR}/canokey-qemu.pc
+        	DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig)
+else()
+	configure_file(canokey-qemu.pc.in canokey-qemu.pc @ONLY)
+	install(FILES ${CMAKE_BINARY_DIR}/canokey-qemu.pc
+        	DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig)
+endif()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,13 +24,16 @@ set(LIBCANOKEY_QEMU_INCLUDEDIR ${CMAKE_INSTALL_FULL_INCLUDEDIR})
 file(GLOB_RECURSE SRC Src/*.c)
 
 if(${APPLE})
-	add_library(canokey-qemu STATIC ${SRC}
-else()
-	add_library(canokey-qemu SHARED ${SRC}
-endif()
+	add_library(canokey-qemu STATIC ${SRC} 
         canokey-core/virt-card/device-sim.c
         canokey-core/virt-card/fabrication.c
         canokey-core/littlefs/bd/lfs_filebd.c)
+else()
+	add_library(canokey-qemu SHARED ${SRC}
+        canokey-core/virt-card/device-sim.c
+        canokey-core/virt-card/fabrication.c
+        canokey-core/littlefs/bd/lfs_filebd.c)
+endif()
 set_target_properties(canokey-qemu PROPERTIES PUBLIC_HEADER Inc/canokey-qemu.h)
 set_target_properties(canokey-qemu PROPERTIES SOVERSION ${LIBCANOKEY_QEMU_SO_VERSION})
 target_include_directories(canokey-qemu SYSTEM PRIVATE Inc canokey-core/virt-card canokey-core)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ if(${APPLE})
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-but-set-variable -Wno-unused-but-set-parameter")
 endif()
 ```
+When building QEMU with the `--enable-canokey` option add the additional option to point to the static library: `--extra-ldflags='-L/usr/local/lib -lcanokey-qemu'`.  Note: if your libraries from `make install` for canokey-qemu went into a directory other than `/usr/local/lib` update the `--extra-ldflags` path as needed.
 
 ## Doc
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,12 @@ make install
 ```
 
 ## Install (Mac)
-Add the following to the very top of the file `canokey-core/canokey-crypto/mbedtls/library/CMakeLists.txt`:
+Follow the regular install instructions, and then after cloning the repo and cd'ing into it, add the code below to the very top of the file `canokey-core/canokey-crypto/mbedtls/library/CMakeLists.txt`.  Then follow the rest of the regular instructions.:
 ```
 if(${APPLE})
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-but-set-variable -Wno-unused-but-set-parameter")
 endif()
 ```
-When building QEMU with the `--enable-canokey` option add the additional option to point to the static library: `--extra-ldflags='-L/usr/local/lib -lcanokey-qemu'`.  Note: if your libraries from `make install` for canokey-qemu went into a directory other than `/usr/local/lib` update the `--extra-ldflags` path as needed.
 
 ## Doc
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ make -j`nproc`
 make install
 ```
 
+## Install (Mac)
+Add the following to the very top of the file `canokey-core/canokey-crypto/mbedtls/library/CMakeLists.txt`:
+```
+if(${APPLE})
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-but-set-variable -Wno-unused-but-set-parameter")
+endif()
+```
+
 ## Doc
 
 See <https://www.qemu.org/docs/master/system/devices/canokey.html>

--- a/canokey-qemu_mac.pc.in
+++ b/canokey-qemu_mac.pc.in
@@ -5,5 +5,5 @@ includedir=@LIBCANOKEY_QEMU_INCLUDEDIR@
 Name: libcanokey-qemu
 Description: CanoKey lib for QEMU
 Version: @LIBCANOKEY_QEMU_SO_VERSION@
-Libs: -L${libdir} -lcanokey-qemu -lcanokey-crypto -lmbedcrypto -lcanokey-core
+Libs: -L${libdir} -lcanokey-qemu -lcanokey-crypto -l:libmbedcrypto.a -lcanokey-core
 Cflags: -I${includedir}

--- a/canokey-qemu_mac.pc.in
+++ b/canokey-qemu_mac.pc.in
@@ -5,5 +5,5 @@ includedir=@LIBCANOKEY_QEMU_INCLUDEDIR@
 Name: libcanokey-qemu
 Description: CanoKey lib for QEMU
 Version: @LIBCANOKEY_QEMU_SO_VERSION@
-Libs: -L${libdir} -lcanokey-qemu 
+Libs: -L${libdir} -lcanokey-qemu -lcanokey-crypto -lmbedcrypto -lcanokey-core
 Cflags: -I${includedir}


### PR DESCRIPTION
Several changes are necessary to successfully build on MacOS with clang.

1. Changed library compilation target from shared to static for canokey-qemu.
2. Added Mac pkg-config script to install all static library dependencies built to standard library path and updated CMakeLists.txt to select Mac pkg-config script when running on a Mac.
3. Added instructions to README for editing CMakeLists.txt for mbedTLS.  As several submodules are pinned to certain commits this was the most straightforward way I found to provide the necessary changes only for canokey-qemu all in one place (rather than making a separate PR for mbedTLS that's unrelated to that project).